### PR TITLE
Rename Select-PermanentAlerts to Select-WhatIf and output all alerts

### DIFF
--- a/FabricUpgradePowerShellModule/FabricUpgradePowerShellModule/ExposedCommands.cs
+++ b/FabricUpgradePowerShellModule/FabricUpgradePowerShellModule/ExposedCommands.cs
@@ -170,10 +170,10 @@ namespace FabricUpgradePowerShellModule
     }
 
     // This cmdlet takes the progress payload produced by ConvertTo-FabricResources
-    // Import-AdfSupportFile '...' | ConvertTo-FabricResources | Select-PermanentAlerts
-    // This cmdlet outputs whether the conversion to Fabric resources will succeed and permanent alerts if present.
-    [Cmdlet("Select", "PermanentAlerts")]
-    public class SelectPermanentAlerts : Cmdlet
+    // Import-AdfSupportFile '...' | ConvertTo-FabricResources | Select-WhatIf
+    // This cmdlet outputs whether the conversion to Fabric resources will succeed and alerts.
+    [Cmdlet("Select", "WhatIf")]
+    public class SelectWhatIf : Cmdlet
     {
         [Parameter(
             Position = 0,
@@ -189,7 +189,7 @@ namespace FabricUpgradePowerShellModule
 
         protected override void ProcessRecord()
         {
-            string result = new FabricUpgradeHandler().SelectPermanentAlerts(this.progress).ToString();
+            string result = new FabricUpgradeHandler().SelectWhatIf(this.progress).ToString();
             WriteObject(result);
         }
     }

--- a/FabricUpgradePowerShellModule/FabricUpgradePowerShellModule/FabricUpgradeHandler.cs
+++ b/FabricUpgradePowerShellModule/FabricUpgradePowerShellModule/FabricUpgradeHandler.cs
@@ -101,11 +101,11 @@ namespace FabricUpgradePowerShellModule
 
         /// <summary>
         /// Accept a Progress that includes the result of ConvertTo-FabricResources and
-        /// selects only the permanent alerts and state
+        /// selects only alerts and state
         /// </summary>
         /// <param name="progressString">The progress sent by the client.</param>
-        /// <returns>A FabricUpgradeProgress that contains only the Permanent alerts.</returns>
-        public FabricUpgradeProgress SelectPermanentAlerts(
+        /// <returns>A FabricUpgradeProgress that contains state and alerts.</returns>
+        public FabricUpgradeProgress SelectWhatIf(
             string progressString)
         {
             if (!this.CheckValidJSON(progressString, out FabricUpgradeProgress previousProgress))
@@ -119,10 +119,7 @@ namespace FabricUpgradePowerShellModule
             List<FabricUpgradeAlert> alerts = new List<FabricUpgradeAlert>();
             foreach (FabricUpgradeAlert alert in previousProgress.Alerts)
             {
-                if (alert.Severity == FabricUpgradeAlert.AlertSeverity.Permanent)
-                {
-                    alerts.Add(alert);
-                }
+                alerts.Add(alert);
             }
             return new FabricUpgradeProgress()
             {

--- a/FabricUpgradePowerShellModule/FabricUpgradePowerShellModule/ToPublish/Microsoft.FabricUpgrade.psd1
+++ b/FabricUpgradePowerShellModule/FabricUpgradePowerShellModule/ToPublish/Microsoft.FabricUpgrade.psd1
@@ -77,7 +77,7 @@ CmdletsToExport = @(
     "ConvertTo-FabricResources",
     "Import-FabricResolutions",
     "Export-FabricResources",
-    "Select-PermanentAlerts"
+    "Select-WhatIf"
 )
 
 # Variables to export from this module

--- a/FabricUpgradePowerShellModule/FabricUpgradePowerShellModuleTests/EndToEndTests.cs
+++ b/FabricUpgradePowerShellModule/FabricUpgradePowerShellModuleTests/EndToEndTests.cs
@@ -116,7 +116,7 @@ namespace FabricUpgradePowerShellModuleTests
 
             runningProgress = new FabricUpgradeHandler().ConvertToFabricResources(runningProgress?.ToString());
 
-            FabricUpgradeProgress whatIfProgress = new FabricUpgradeHandler().SelectPermanentAlerts(runningProgress?.ToString());
+            FabricUpgradeProgress whatIfProgress = new FabricUpgradeHandler().SelectWhatIf(runningProgress?.ToString());
 
             foreach (FabricUpgradeResolution resolution in testConfig.Resolutions)
             {

--- a/FabricUpgradePowerShellModule/FabricUpgradePowerShellModuleTests/TestFiles/E2ePipelineWithTriggerAndUnsupportedActivity.json
+++ b/FabricUpgradePowerShellModule/FabricUpgradePowerShellModuleTests/TestFiles/E2ePipelineWithTriggerAndUnsupportedActivity.json
@@ -77,6 +77,20 @@
   "expectedEndpointEvents": [
     "LIST DataPipeline",
     "CREATE DataPipeline 'pipelineWithTriggerAndUnsupportedActivity' => $0"
-  ]
+  ],
+
+  "expectedWhatIfResponse": {
+    "state": "Succeeded",
+    "alerts": [
+      {
+        "severity": "Warning",
+        "details": "Cannot upgrade the ScheduleTrigger 'trigger1'; Fabric Upgrade does not yet support upgrading Triggers"
+      },
+      {
+        "severity": "Warning",
+        "details": "Cannot upgrade Activity 'pipelineWithTriggerAndUnsupportedActivity/Execute SSIS package1'; please inspect this Activity for more details"
+      }
+    ]
+  }
 
 }

--- a/FabricUpgradePowerShellModule/FabricUpgradePowerShellModuleTests/TestFiles/E2ePipelineWithUnsupportedActivity.json
+++ b/FabricUpgradePowerShellModule/FabricUpgradePowerShellModuleTests/TestFiles/E2ePipelineWithUnsupportedActivity.json
@@ -56,6 +56,16 @@
   "expectedEndpointEvents": [
     "LIST DataPipeline",
     "CREATE DataPipeline 'PipelineWithUnsupportedActivity' => $0"
-  ]
+  ],
+
+  "expectedWhatIfResponse": {
+    "state": "Succeeded",
+    "alerts": [
+      {
+        "severity": "Warning",
+        "details": "Cannot upgrade the ScheduleTrigger 'trigger1'; Fabric Upgrade does not yet support upgrading Triggers"
+      }
+    ]
+  }
 
 }


### PR DESCRIPTION
Rename Select-PermanentAlerts to Select-WhatIf to make it more intuitive. Also stopped filtering alerts as we also want to show UnsupportedResources alerts.