### PR TITLE
Support API mode to fetch resources, and Factory level Upgrade

### DIFF
--- a/FabricUpgradePowerShellModule/FabricUpgradePowerShellModule/AdfApiClient.cs
+++ b/FabricUpgradePowerShellModule/FabricUpgradePowerShellModule/AdfApiClient.cs
@@ -1,0 +1,343 @@
+// <copyright file="AdfApiClient.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// </copyright>
+
+using System.Net;
+using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace FabricUpgradePowerShellModule
+{
+    /// <summary>
+    /// This client interacts with Azure Data Factory REST API endpoints.
+    /// </summary>
+    public class AdfApiClient
+    {
+        private readonly string subscriptionId;
+        private readonly string resourceGroupName;
+        private readonly string factoryName;
+        private readonly string accessToken;
+        private readonly HttpClient httpClient;
+
+        private const string BaseUrl = "https://management.azure.com";
+        private const string ApiVersion = "2018-06-01";
+
+        public AdfApiClient(
+            string subscriptionId,
+            string resourceGroupName,
+            string factoryName,
+            string accessToken)
+        {
+            this.subscriptionId = subscriptionId;
+            this.resourceGroupName = resourceGroupName;
+            this.factoryName = factoryName;
+            this.accessToken = accessToken;
+            
+            this.httpClient = new HttpClient();
+            this.httpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {accessToken}");
+        }
+
+        /// <summary>
+        /// Get all pipelines from the Azure Data Factory.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A dictionary of pipeline names to pipeline definitions.</returns>
+        public async Task<Dictionary<string, JObject>> GetPipelinesAsync(CancellationToken cancellationToken = default)
+        {
+            var pipelines = new Dictionary<string, JObject>();
+            string url = $"{BaseUrl}/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataFactory/factories/{factoryName}/pipelines?api-version={ApiVersion}";
+
+            try
+            {
+                await FetchAllResourcesAsync(url, async (pipelineInfo) =>
+                {
+                    string pipelineName = pipelineInfo["name"].ToString();
+                    // Use the pipeline definition directly from the list API response
+                    // No need to call GetPipelineAsync again since list API returns complete definitions
+                    pipelines[pipelineName] = pipelineInfo;
+                }, cancellationToken).ConfigureAwait(false);
+
+                return pipelines;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Error retrieving pipelines from ADF: {ex.Message}", ex);
+            }
+        }
+
+        /// <summary>
+        /// Get all datasets from the Azure Data Factory.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A dictionary of dataset names to dataset definitions.</returns>
+        public async Task<Dictionary<string, JObject>> GetDatasetsAsync(CancellationToken cancellationToken = default)
+        {
+            var datasets = new Dictionary<string, JObject>();
+            string url = $"{BaseUrl}/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataFactory/factories/{factoryName}/datasets?api-version={ApiVersion}";
+
+            try
+            {
+                await FetchAllResourcesAsync(url, async (datasetInfo) =>
+                {
+                    string datasetName = datasetInfo["name"].ToString();
+                    // Use the dataset definition directly from the list API response
+                    // No need to call GetDatasetAsync again since list API returns complete definitions
+                    datasets[datasetName] = datasetInfo;
+                }, cancellationToken).ConfigureAwait(false);
+
+                return datasets;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Error retrieving datasets from ADF: {ex.Message}", ex);
+            }
+        }
+
+        /// <summary>
+        /// Get a specific dataset from the Azure Data Factory.
+        /// </summary>
+        /// <param name="datasetName">The name of the dataset.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The dataset definition.</returns>
+        public async Task<JObject> GetDatasetAsync(string datasetName, CancellationToken cancellationToken = default)
+        {
+            string url = $"{BaseUrl}/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataFactory/factories/{factoryName}/datasets/{datasetName}?api-version={ApiVersion}";
+
+            try
+            {
+                HttpResponseMessage response = await httpClient.GetAsync(url, cancellationToken).ConfigureAwait(false);
+                
+                if (!response.IsSuccessStatusCode)
+                {
+                    throw new Exception($"Failed to get dataset '{datasetName}': {response.StatusCode} - {await response.Content.ReadAsStringAsync()}");
+                }
+
+                string responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                return JObject.Parse(responseContent);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Error retrieving dataset '{datasetName}' from ADF: {ex.Message}", ex);
+            }
+        }
+
+        /// <summary>
+        /// Get all linked services from the Azure Data Factory.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A dictionary of linked service names to linked service definitions.</returns>
+        public async Task<Dictionary<string, JObject>> GetLinkedServicesAsync(CancellationToken cancellationToken = default)
+        {
+            var linkedServices = new Dictionary<string, JObject>();
+            string url = $"{BaseUrl}/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataFactory/factories/{factoryName}/linkedservices?api-version={ApiVersion}";
+
+            try
+            {
+                await FetchAllResourcesAsync(url, async (linkedServiceInfo) =>
+                {
+                    string linkedServiceName = linkedServiceInfo["name"].ToString();
+                    // Use the linked service definition directly from the list API response
+                    // No need to call GetLinkedServiceAsync again since list API returns complete definitions
+                    linkedServices[linkedServiceName] = linkedServiceInfo;
+                }, cancellationToken).ConfigureAwait(false);
+
+                return linkedServices;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Error retrieving linked services from ADF: {ex.Message}", ex);
+            }
+        }
+
+        /// <summary>
+        /// Get a specific linked service from the Azure Data Factory.
+        /// </summary>
+        /// <param name="linkedServiceName">The name of the linked service.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The linked service definition.</returns>
+        public async Task<JObject> GetLinkedServiceAsync(string linkedServiceName, CancellationToken cancellationToken = default)
+        {
+            string url = $"{BaseUrl}/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataFactory/factories/{factoryName}/linkedservices/{linkedServiceName}?api-version={ApiVersion}";
+
+            try
+            {
+                HttpResponseMessage response = await httpClient.GetAsync(url, cancellationToken).ConfigureAwait(false);
+                
+                if (!response.IsSuccessStatusCode)
+                {
+                    throw new Exception($"Failed to get linked service '{linkedServiceName}': {response.StatusCode} - {await response.Content.ReadAsStringAsync()}");
+                }
+
+                string responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                return JObject.Parse(responseContent);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Error retrieving linked service '{linkedServiceName}' from ADF: {ex.Message}", ex);
+            }
+        }
+
+        /// <summary>
+        /// Get all triggers from the Azure Data Factory.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A dictionary of trigger names to trigger definitions.</returns>
+        public async Task<Dictionary<string, JObject>> GetTriggersAsync(CancellationToken cancellationToken = default)
+        {
+            var triggers = new Dictionary<string, JObject>();
+            string url = $"{BaseUrl}/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataFactory/factories/{factoryName}/triggers?api-version={ApiVersion}";
+
+            try
+            {
+                await FetchAllResourcesAsync(url, async (triggerInfo) =>
+                {
+                    string triggerName = triggerInfo["name"].ToString();
+                    // Use the trigger definition directly from the list API response
+                    // No need to call GetTriggerAsync again since list API returns complete definitions
+                    triggers[triggerName] = triggerInfo;
+                }, cancellationToken).ConfigureAwait(false);
+
+                return triggers;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Error retrieving triggers from ADF: {ex.Message}", ex);
+            }
+        }
+
+        /// <summary>
+        /// Get a specific trigger from the Azure Data Factory.
+        /// </summary>
+        /// <param name="triggerName">The name of the trigger.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The trigger definition.</returns>
+        public async Task<JObject> GetTriggerAsync(string triggerName, CancellationToken cancellationToken = default)
+        {
+            string url = $"{BaseUrl}/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataFactory/factories/{factoryName}/triggers/{triggerName}?api-version={ApiVersion}";
+
+            try
+            {
+                HttpResponseMessage response = await httpClient.GetAsync(url, cancellationToken).ConfigureAwait(false);
+                
+                if (!response.IsSuccessStatusCode)
+                {
+                    throw new Exception($"Failed to get trigger '{triggerName}': {response.StatusCode} - {await response.Content.ReadAsStringAsync()}");
+                }
+
+                string responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                return JObject.Parse(responseContent);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Error retrieving trigger '{triggerName}' from ADF: {ex.Message}", ex);
+            }
+        }
+
+        /// <summary>
+        /// Get the Data Factory information.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The Data Factory information.</returns>
+        public async Task<JObject> GetDataFactoryAsync(CancellationToken cancellationToken = default)
+        {
+            string url = $"{BaseUrl}/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataFactory/factories/{factoryName}?api-version={ApiVersion}";
+
+            try
+            {
+                HttpResponseMessage response = await httpClient.GetAsync(url, cancellationToken).ConfigureAwait(false);
+                
+                if (!response.IsSuccessStatusCode)
+                {
+                    throw new Exception($"Failed to get data factory: {response.StatusCode} - {await response.Content.ReadAsStringAsync()}");
+                }
+
+                string responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                return JObject.Parse(responseContent);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Error retrieving data factory information: {ex.Message}", ex);
+            }
+        }
+
+        /// <summary>
+        /// Dispose of the HTTP client.
+        /// </summary>
+        public void Dispose()
+        {
+            httpClient?.Dispose();
+        }
+
+        /// <summary>
+        /// Helper method to fetch all resources from a paginated API endpoint.
+        /// Handles continuation tokens automatically.
+        /// </summary>
+        /// <param name="initialUrl">The initial URL to start fetching from.</param>
+        /// <param name="processResourceFunc">Function to process each resource item.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A task that completes when all resources have been fetched and processed.</returns>
+        private async Task FetchAllResourcesAsync(
+            string initialUrl, 
+            Func<JObject, Task> processResourceFunc, 
+            CancellationToken cancellationToken = default)
+        {
+            string currentUrl = initialUrl;
+            
+            do
+            {
+                HttpResponseMessage response = await httpClient.GetAsync(currentUrl, cancellationToken).ConfigureAwait(false);
+                
+                if (!response.IsSuccessStatusCode)
+                {
+                    throw new Exception($"Failed to fetch resources from {currentUrl}: {response.StatusCode} - {await response.Content.ReadAsStringAsync()}");
+                }
+
+                string responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                JObject responseObj = JObject.Parse(responseContent);
+                
+                // Process all items in the current page
+                JArray resourceList = (JArray)responseObj["value"];
+                if (resourceList != null)
+                {
+                    foreach (JObject resource in resourceList)
+                    {
+                        await processResourceFunc(resource).ConfigureAwait(false);
+                    }
+                }
+
+                // Check for continuation token (nextLink)
+                currentUrl = responseObj["nextLink"]?.ToString();
+                
+            } while (!string.IsNullOrEmpty(currentUrl));
+        }
+
+        /// <summary>
+        /// Get a specific pipeline from the Azure Data Factory.
+        /// </summary>
+        /// <param name="pipelineName">The name of the pipeline.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The pipeline definition.</returns>
+        public async Task<JObject> GetPipelineAsync(string pipelineName, CancellationToken cancellationToken = default)
+        {
+            string url = $"{BaseUrl}/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataFactory/factories/{factoryName}/pipelines/{pipelineName}?api-version={ApiVersion}";
+
+            try
+            {
+                HttpResponseMessage response = await httpClient.GetAsync(url, cancellationToken).ConfigureAwait(false);
+                
+                if (!response.IsSuccessStatusCode)
+                {
+                    throw new Exception($"Failed to get pipeline '{pipelineName}': {response.StatusCode} - {await response.Content.ReadAsStringAsync()}");
+                }
+
+                string responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                return JObject.Parse(responseContent);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Error retrieving pipeline '{pipelineName}' from ADF: {ex.Message}", ex);
+            }
+        }
+    }
+}

--- a/FabricUpgradePowerShellModule/FabricUpgradePowerShellModule/ExposedCommands.cs
+++ b/FabricUpgradePowerShellModule/FabricUpgradePowerShellModule/ExposedCommands.cs
@@ -36,9 +36,103 @@ namespace FabricUpgradePowerShellModule
         }
         private string filename;
 
+
         protected override void ProcessRecord()
         {
-            WriteObject(new FabricUpgradeHandler().ImportAdfSupportFile(this.progress, this.filename).ToString());
+            var result = new FabricUpgradeHandler().ImportAdfSupportFile(
+                this.progress, 
+                this.filename, 
+                true,
+                CancellationToken.None);
+
+            WriteObject(result.ToString());
+        }
+    }
+
+    /// <summary>
+    /// Import ADF resources directly from Azure Data Factory using REST APIs.
+    /// </summary>
+    [Cmdlet(VerbsData.Import, "AdfFactory")]
+    public class ImportAdfFactory : Cmdlet
+    {
+        [Parameter(
+            Position = 0,
+            ValueFromPipeline = true,
+            ValueFromPipelineByPropertyName = true)]
+        [ValidateNotNullOrEmpty]
+        public string Progress
+        {
+            get { return progress; }
+            set { progress = value; }
+        }
+        private string progress;
+
+        [Parameter(Mandatory = true)]
+        public string SubscriptionId
+        {
+            get { return subscriptionId; }
+            set { subscriptionId = value; }
+        }
+        private string subscriptionId;
+
+        [Parameter(Mandatory = true)]
+        public string ResourceGroupName
+        {
+            get { return resourceGroupName; }
+            set { resourceGroupName = value; }
+        }
+        private string resourceGroupName;
+
+        [Parameter(Mandatory = true)]
+        public string FactoryName
+        {
+            get { return factoryName; }
+            set { factoryName = value; }
+        }
+        private string factoryName;
+
+        [Parameter(Mandatory = true)]
+        public string AdfToken
+        {
+            get { return adfToken; }
+            set { adfToken = value; }
+        }
+        private string adfToken;
+
+        [Parameter(Mandatory = false)]
+        public string PipelineName
+        {
+            get { return pipelineName; }
+            set { pipelineName = value; }
+        }
+        private string pipelineName;
+
+        /// <summary>
+        /// Include datasets and linked services that are not used by any pipelines.
+        /// By default, only resources used by pipelines are imported to avoid upgrade failures from unsupported linked service types.
+        /// Set this to $true for factory-level upgrades where you want to include all resources regardless of usage.
+        /// </summary>
+        [Parameter(Mandatory = false, HelpMessage = "Include datasets and linked services that are not used by any pipelines. Useful for factory-level upgrades.")]
+        public SwitchParameter IncludeUnusedResources
+        {
+            get { return includeUnusedResources; }
+            set { includeUnusedResources = value; }
+        }
+        private SwitchParameter includeUnusedResources;
+
+        protected override void ProcessRecord()
+        {
+            var task = new FabricUpgradeHandler().ImportAdfFactoryAsync(
+                this.progress,
+                this.subscriptionId,
+                this.resourceGroupName,
+                this.factoryName,
+                this.adfToken,
+                this.pipelineName,
+                this.includeUnusedResources,
+                CancellationToken.None);
+
+            WriteObject(task.Result.ToString());
         }
     }
 

--- a/FabricUpgradePowerShellModule/FabricUpgradePowerShellModule/FabricUpgradeHandler.cs
+++ b/FabricUpgradePowerShellModule/FabricUpgradePowerShellModule/FabricUpgradeHandler.cs
@@ -26,28 +26,100 @@ namespace FabricUpgradePowerShellModule
         public FabricUpgradeHandler() { }
 
         /// <summary>
-        /// Import an ADF Support File.
+        /// Import an ADF Support File (zip file).
         /// </summary>
-        /// <remarks>
-        /// ADF Studio can export a "Support File" that contains a Pipeline and all of the other 
-        /// ADF resources upon which that Pipeline depends (including other Pipelines!).
-        /// </remarks>
         /// <param name="progressString">The progress sent by the client.</param>
         /// <param name="fileName">The name of the ADF support file to import.</param>
+        /// <param name="includeUnusedResources">Whether to include datasets and linked services that are not used by any pipelines.</param>
         /// <returns>A FabricUpgradeProgress that contains the unzipped contents of the ADF Support File.</returns>
         public FabricUpgradeProgress ImportAdfSupportFile(
             string progressString,
-            string fileName)
+            string fileName,
+            bool includeUnusedResources,
+            CancellationToken cancellationToken = default)
         {
             if (!this.CheckProgress(progressString, out FabricUpgradeProgress progress))
             {
                 return progress;
             }
 
-            AdfSupportFileImporter importer = new AdfSupportFileImporter(progress, fileName, this.alerts);
+            Console.WriteLine($"ImportAdfSupportFile: fileName={fileName}, includeUnusedResources={includeUnusedResources}");
 
-            return importer.Import();
+            if (string.IsNullOrEmpty(fileName))
+            {
+                return new FabricUpgradeProgress()
+                {
+                    State = FabricUpgradeProgress.FabricUpgradeState.Failed,
+                }
+                .WithAlert(
+                    new FabricUpgradeAlert()
+                    {
+                        Severity = FabricUpgradeAlert.AlertSeverity.Permanent,
+                        Details = "Filename is required for ADF Support File import.",
+                    });
+            }
+
+            AdfSupportFileImporter fileImporter = new AdfSupportFileImporter(progress, fileName, this.alerts);
+            return fileImporter.Import(includeUnusedResources);
         }
+
+        /// <summary>
+        /// Import ADF resources directly from Azure Data Factory using REST APIs.
+        /// </summary>
+        /// <param name="progressString">The progress sent by the client.</param>
+        /// <param name="subscriptionId">Azure subscription ID for ADF API access.</param>
+        /// <param name="resourceGroupName">Resource group name for ADF API access.</param>
+        /// <param name="factoryName">Data factory name for ADF API access.</param>
+        /// <param name="adfToken">The ADF token used for authentication.</param>
+        /// <param name="pipelineResourceId">Optional specific pipeline resource Id to import.</param>
+        /// <param name="includeUnusedResources">Whether to include datasets and linked services that are not used by any pipelines.</param>
+        /// <returns>A FabricUpgradeProgress that contains the imported ADF resources.</returns>
+        public async Task<FabricUpgradeProgress> ImportAdfFactoryAsync(
+            string progressString,
+            string subscriptionId,
+            string resourceGroupName,
+            string factoryName,
+            string adfToken,
+            string pipelineResourceId,
+            bool includeUnusedResources,
+            CancellationToken cancellationToken = default)
+        {
+            if (!this.CheckProgress(progressString, out FabricUpgradeProgress progress))
+            {
+                return progress;
+            }
+
+            Console.WriteLine($"ImportAdfFactory: factoryName={factoryName}, pipelineResourceId={pipelineResourceId}, includeUnusedResources={includeUnusedResources}");
+
+            if (string.IsNullOrEmpty(subscriptionId) || 
+                string.IsNullOrEmpty(resourceGroupName) || 
+                string.IsNullOrEmpty(factoryName) || 
+                string.IsNullOrEmpty(adfToken))
+            {
+                return new FabricUpgradeProgress()
+                {
+                    State = FabricUpgradeProgress.FabricUpgradeState.Failed,
+                }
+                .WithAlert(
+                    new FabricUpgradeAlert()
+                    {
+                        Severity = FabricUpgradeAlert.AlertSeverity.Permanent,
+                        Details = "SubscriptionId, ResourceGroupName, FactoryName, and AdfToken are all required for ADF API import.",
+                    });
+            }
+
+            AdfApiImporter apiImporter = new AdfApiImporter(
+                progress, 
+                subscriptionId, 
+                resourceGroupName, 
+                factoryName, 
+                adfToken, 
+                pipelineResourceId, 
+                this.alerts);
+
+            return await apiImporter.ImportAsync(includeUnusedResources, cancellationToken).ConfigureAwait(false);
+        }
+
 
         /// <summary>
         /// Accept a Progress that includes the result of Import-AdfSupportFile and

--- a/FabricUpgradePowerShellModule/FabricUpgradePowerShellModule/Importers/AdfApiImporter.cs
+++ b/FabricUpgradePowerShellModule/FabricUpgradePowerShellModule/Importers/AdfApiImporter.cs
@@ -1,0 +1,401 @@
+// <copyright file="AdfApiImporter.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// </copyright>
+
+using FabricUpgradePowerShellModule.Models;
+using FabricUpgradePowerShellModule.Utilities;
+using Newtonsoft.Json.Linq;
+
+namespace FabricUpgradePowerShellModule.Importers
+{
+    /// <summary>
+    /// This class imports ADF resources using Azure Data Factory REST APIs.
+    /// </summary>
+    public class AdfApiImporter
+    {
+        private readonly FabricUpgradeProgress progress;
+        private readonly string subscriptionId;
+        private readonly string resourceGroupName;
+        private readonly string factoryName;
+        private readonly string accessToken;
+        private readonly string pipelineResourceId;
+        private readonly AlertCollector alerts;
+
+        private readonly AdfSupportFileUpgradePackage upgradePackage = new AdfSupportFileUpgradePackage();
+
+        public AdfApiImporter(
+            FabricUpgradeProgress progress,
+            string subscriptionId,
+            string resourceGroupName,
+            string factoryName,
+            string accessToken,
+            string pipelineResourceId,
+            AlertCollector alerts)
+        {
+            this.progress = progress;
+            this.subscriptionId = subscriptionId;
+            this.resourceGroupName = resourceGroupName;
+            this.factoryName = factoryName;
+            this.accessToken = accessToken;
+            this.pipelineResourceId = pipelineResourceId;
+            this.alerts = alerts;
+        }
+
+        /// <summary>
+        /// Import ADF resources using REST APIs.
+        /// </summary>
+        /// <param name="includeUnusedResources">Whether to include datasets and linked services that are not used by any pipelines.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A FabricUpgradeProgress containing the imported resources.</returns>
+        public async Task<FabricUpgradeProgress> ImportAsync(bool includeUnusedResources = true, CancellationToken cancellationToken = default)
+        {
+            AdfApiClient adfClient = null;
+            try
+            {
+                adfClient = new AdfApiClient(subscriptionId, resourceGroupName, factoryName, accessToken);
+                
+                // Get Data Factory information for the ADF name
+                JObject dataFactory = await adfClient.GetDataFactoryAsync(cancellationToken).ConfigureAwait(false);
+                this.upgradePackage.AdfName = dataFactory["name"]?.ToString() ?? factoryName;
+
+                // If a specific pipeline is requested, import only that pipeline and its dependencies
+                if (!string.IsNullOrEmpty(pipelineResourceId))
+                {
+                    await ImportSpecificPipelineAsync(adfClient, pipelineResourceId, cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    // Import all resources
+                    await ImportAllResourcesAsync(adfClient, includeUnusedResources, cancellationToken).ConfigureAwait(false);
+                }
+
+                return new FabricUpgradeProgress()
+                {
+                    State = FabricUpgradeProgress.FabricUpgradeState.Succeeded,
+                    Alerts = this.alerts.ToList(),
+                    Result = this.BuildResult(),
+                    Resolutions = this.progress.Resolutions,
+                };
+            }
+            catch (Exception ex)
+            {
+                return new FabricUpgradeProgress()
+                {
+                    State = FabricUpgradeProgress.FabricUpgradeState.Failed,
+                    Alerts = this.alerts.ToList(),
+                }
+                .WithAlert(
+                    new FabricUpgradeAlert()
+                    {
+                        Severity = FabricUpgradeAlert.AlertSeverity.Permanent,
+                        Details = $"Failed to import from ADF: {ex.Message}",
+                    });
+            }
+            finally
+            {
+                adfClient?.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Import all resources from the Data Factory.
+        /// </summary>
+        /// <param name="adfClient">The ADF API client.</param>
+        /// <param name="includeUnusedResources">Whether to include unused resources.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        private async Task ImportAllResourcesAsync(AdfApiClient adfClient, bool includeUnusedResources, CancellationToken cancellationToken)
+        {
+            // Import all pipelines first
+            var pipelines = await adfClient.GetPipelinesAsync(cancellationToken).ConfigureAwait(false);
+            foreach (var pipeline in pipelines)
+            {
+                this.upgradePackage.Pipelines[pipeline.Key] = pipeline.Value;
+            }
+
+            // Get all available datasets and linked services once
+            var allDatasets = await adfClient.GetDatasetsAsync(cancellationToken).ConfigureAwait(false);
+            var allLinkedServices = await adfClient.GetLinkedServicesAsync(cancellationToken).ConfigureAwait(false);
+
+            if (includeUnusedResources)
+            {
+                // Import all datasets and linked services
+                foreach (var dataset in allDatasets)
+                {
+                    this.upgradePackage.Datasets[dataset.Key] = dataset.Value;
+                }
+
+                foreach (var linkedService in allLinkedServices)
+                {
+                    this.upgradePackage.LinkedServices[linkedService.Key] = linkedService.Value;
+                }
+            }
+            else
+            {
+                // Use the common filtering logic from DependencyAnalyzer
+                var (filteredDatasets, filteredLinkedServices) = DependencyAnalyzer.FilterUnusedResources(
+                    this.upgradePackage.Pipelines,
+                    allDatasets,
+                    allLinkedServices,
+                    this.alerts);
+
+                // Import the filtered resources into the upgrade package
+                foreach (var dataset in filteredDatasets)
+                {
+                    this.upgradePackage.Datasets[dataset.Key] = dataset.Value;
+                }
+
+                foreach (var linkedService in filteredLinkedServices)
+                {
+                    this.upgradePackage.LinkedServices[linkedService.Key] = linkedService.Value;
+                }
+            }
+
+            // Import all triggers (triggers are not subject to dependency filtering)
+            var triggers = await adfClient.GetTriggersAsync(cancellationToken).ConfigureAwait(false);
+            foreach (var trigger in triggers)
+            {
+                this.upgradePackage.Triggers[trigger.Key] = trigger.Value;
+            }
+        }
+
+        /// <summary>
+        /// Import a specific pipeline and its dependencies.
+        /// </summary>
+        /// <param name="adfClient">The ADF API client.</param>
+        /// <param name="pipelineName">The name of the pipeline to import.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        private async Task ImportSpecificPipelineAsync(AdfApiClient adfClient, string pipelineName, CancellationToken cancellationToken)
+        {
+            var importedDatasets = new HashSet<string>();
+            var importedLinkedServices = new HashSet<string>();
+            var importedPipelines = new HashSet<string>();
+
+            // Import the main pipeline
+            await ImportPipelineWithDependenciesAsync(adfClient, pipelineName, importedPipelines, importedDatasets, importedLinkedServices, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Recursively import a pipeline and all its dependencies.
+        /// </summary>
+        /// <param name="adfClient">The ADF API client.</param>
+        /// <param name="pipelineName">The name of the pipeline to import.</param>
+        /// <param name="importedPipelines">Set of already imported pipeline names.</param>
+        /// <param name="importedDatasets">Set of already imported dataset names.</param>
+        /// <param name="importedLinkedServices">Set of already imported linked service names.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        private async Task ImportPipelineWithDependenciesAsync(
+            AdfApiClient adfClient, 
+            string pipelineName, 
+            HashSet<string> importedPipelines,
+            HashSet<string> importedDatasets,
+            HashSet<string> importedLinkedServices,
+            CancellationToken cancellationToken)
+        {
+            if (importedPipelines.Contains(pipelineName))
+            {
+                return; // Already imported
+            }
+
+            try
+            {
+                // Import the pipeline
+                JObject pipeline = await adfClient.GetPipelineAsync(pipelineName, cancellationToken).ConfigureAwait(false);
+                this.upgradePackage.Pipelines[pipelineName] = pipeline;
+                importedPipelines.Add(pipelineName);
+
+                // Find and import dependencies from the pipeline activities
+                await ImportPipelineDependenciesAsync(adfClient, pipeline, importedPipelines, importedDatasets, importedLinkedServices, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                this.alerts.AddWarning($"Failed to import pipeline '{pipelineName}': {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Import dependencies found in a pipeline's activities.
+        /// </summary>
+        /// <param name="adfClient">The ADF API client.</param>
+        /// <param name="pipeline">The pipeline definition.</param>
+        /// <param name="importedPipelines">Set of already imported pipeline names.</param>
+        /// <param name="importedDatasets">Set of already imported dataset names.</param>
+        /// <param name="importedLinkedServices">Set of already imported linked service names.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        private async Task ImportPipelineDependenciesAsync(
+            AdfApiClient adfClient,
+            JObject pipeline,
+            HashSet<string> importedPipelines,
+            HashSet<string> importedDatasets,
+            HashSet<string> importedLinkedServices,
+            CancellationToken cancellationToken)
+        {
+            JArray activities = pipeline.SelectToken("properties.activities") as JArray;
+            if (activities == null) return;
+
+            foreach (JObject activity in activities)
+            {
+                // Import datasets referenced by Copy activities
+                await ImportActivityDatasetsAsync(adfClient, activity, importedDatasets, importedLinkedServices, cancellationToken).ConfigureAwait(false);
+
+                // Import pipelines referenced by ExecutePipeline activities
+                await ImportReferencedPipelinesAsync(adfClient, activity, importedPipelines, importedDatasets, importedLinkedServices, cancellationToken).ConfigureAwait(false);
+
+                // Import linked services referenced by Web activities
+                await ImportActivityLinkedServicesAsync(adfClient, activity, importedLinkedServices, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Import datasets referenced by an activity.
+        /// </summary>
+        private async Task ImportActivityDatasetsAsync(
+            AdfApiClient adfClient,
+            JObject activity,
+            HashSet<string> importedDatasets,
+            HashSet<string> importedLinkedServices,
+            CancellationToken cancellationToken)
+        {
+            // Check inputs and outputs for dataset references
+            var inputs = activity.SelectToken("inputs") as JArray;
+            var outputs = activity.SelectToken("outputs") as JArray;
+
+            if (inputs != null)
+            {
+                foreach (JObject input in inputs)
+                {
+                    string datasetName = input.SelectToken("referenceName")?.ToString();
+                    if (!string.IsNullOrEmpty(datasetName))
+                    {
+                        await ImportDatasetWithLinkedServiceAsync(adfClient, datasetName, importedDatasets, importedLinkedServices, cancellationToken).ConfigureAwait(false);
+                    }
+                }
+            }
+
+            if (outputs != null)
+            {
+                foreach (JObject output in outputs)
+                {
+                    string datasetName = output.SelectToken("referenceName")?.ToString();
+                    if (!string.IsNullOrEmpty(datasetName))
+                    {
+                        await ImportDatasetWithLinkedServiceAsync(adfClient, datasetName, importedDatasets, importedLinkedServices, cancellationToken).ConfigureAwait(false);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Import pipelines referenced by ExecutePipeline activities.
+        /// </summary>
+        private async Task ImportReferencedPipelinesAsync(
+            AdfApiClient adfClient,
+            JObject activity,
+            HashSet<string> importedPipelines,
+            HashSet<string> importedDatasets,
+            HashSet<string> importedLinkedServices,
+            CancellationToken cancellationToken)
+        {
+            string activityType = activity.SelectToken("type")?.ToString();
+            if (activityType == "ExecutePipeline")
+            {
+                string referencedPipelineName = activity.SelectToken("typeProperties.pipeline.referenceName")?.ToString();
+                if (!string.IsNullOrEmpty(referencedPipelineName))
+                {
+                    await ImportPipelineWithDependenciesAsync(adfClient, referencedPipelineName, importedPipelines, importedDatasets, importedLinkedServices, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Import linked services referenced directly by activities.
+        /// </summary>
+        private async Task ImportActivityLinkedServicesAsync(
+            AdfApiClient adfClient,
+            JObject activity,
+            HashSet<string> importedLinkedServices,
+            CancellationToken cancellationToken)
+        {
+            // Web activities might reference linked services directly
+            string activityType = activity.SelectToken("type")?.ToString();
+            if (activityType == "WebActivity" || activityType == "WebHook")
+            {
+                string linkedServiceName = activity.SelectToken("typeProperties.linkedServiceName.referenceName")?.ToString();
+                if (!string.IsNullOrEmpty(linkedServiceName))
+                {
+                    await ImportLinkedServiceAsync(adfClient, linkedServiceName, importedLinkedServices, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Import a dataset and its linked service.
+        /// </summary>
+        private async Task ImportDatasetWithLinkedServiceAsync(
+            AdfApiClient adfClient,
+            string datasetName,
+            HashSet<string> importedDatasets,
+            HashSet<string> importedLinkedServices,
+            CancellationToken cancellationToken)
+        {
+            if (importedDatasets.Contains(datasetName))
+            {
+                return; // Already imported
+            }
+
+            try
+            {
+                JObject dataset = await adfClient.GetDatasetAsync(datasetName, cancellationToken).ConfigureAwait(false);
+                this.upgradePackage.Datasets[datasetName] = dataset;
+                importedDatasets.Add(datasetName);
+
+                // Import the linked service referenced by this dataset
+                string linkedServiceName = dataset.SelectToken("properties.linkedServiceName.referenceName")?.ToString();
+                if (!string.IsNullOrEmpty(linkedServiceName))
+                {
+                    await ImportLinkedServiceAsync(adfClient, linkedServiceName, importedLinkedServices, cancellationToken).ConfigureAwait(false);
+                }
+            }
+            catch (Exception ex)
+            {
+                this.alerts.AddWarning($"Failed to import dataset '{datasetName}': {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Import a linked service.
+        /// </summary>
+        private async Task ImportLinkedServiceAsync(
+            AdfApiClient adfClient,
+            string linkedServiceName,
+            HashSet<string> importedLinkedServices,
+            CancellationToken cancellationToken)
+        {
+            if (importedLinkedServices.Contains(linkedServiceName))
+            {
+                return; // Already imported
+            }
+
+            try
+            {
+                JObject linkedService = await adfClient.GetLinkedServiceAsync(linkedServiceName, cancellationToken).ConfigureAwait(false);
+                this.upgradePackage.LinkedServices[linkedServiceName] = linkedService;
+                importedLinkedServices.Add(linkedServiceName);
+            }
+            catch (Exception ex)
+            {
+                this.alerts.AddWarning($"Failed to import linked service '{linkedServiceName}': {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Construct the JObject that can be inserted into the FabricUpgradeProgress' Result field.
+        /// </summary>
+        /// <returns>The Result that will be returned to the client in the FabricUpgradeProgress.</returns>
+        public JObject BuildResult()
+        {
+            JObject built = new JObject();
+            built[FabricUpgradeProgress.ImportedResourcesKey] = UpgradeSerialization.ToJToken(upgradePackage);
+            return built;
+        }
+    }
+}

--- a/FabricUpgradePowerShellModule/FabricUpgradePowerShellModule/Importers/AdfSupportFileImporter.cs
+++ b/FabricUpgradePowerShellModule/FabricUpgradePowerShellModule/Importers/AdfSupportFileImporter.cs
@@ -29,7 +29,7 @@ namespace FabricUpgradePowerShellModule.Importers
             this.alerts = alerts;
         }
 
-        public FabricUpgradeProgress Import()
+        public FabricUpgradeProgress Import(bool includeUnusedResources = true)
         {
             byte[] supportFileData;
             try
@@ -67,6 +67,21 @@ namespace FabricUpgradePowerShellModule.Importers
                         Severity = FabricUpgradeAlert.AlertSeverity.Permanent,
                         Details = "Failed to unzip Upgrade Package.",
                     });
+            }
+
+            // Apply dependency filtering if requested
+            if (!includeUnusedResources)
+            {
+                // Use the common filtering logic from DependencyAnalyzer
+                var (filteredDatasets, filteredLinkedServices) = DependencyAnalyzer.FilterUnusedResources(
+                    upgradePackage.Pipelines,
+                    upgradePackage.Datasets,
+                    upgradePackage.LinkedServices,
+                    this.alerts);
+
+                // Update the upgrade package with filtered resources
+                upgradePackage.Datasets = filteredDatasets;
+                upgradePackage.LinkedServices = filteredLinkedServices;
             }
 
             return new FabricUpgradeProgress()

--- a/FabricUpgradePowerShellModule/FabricUpgradePowerShellModule/Utilities/DependencyAnalyzer.cs
+++ b/FabricUpgradePowerShellModule/FabricUpgradePowerShellModule/Utilities/DependencyAnalyzer.cs
@@ -1,0 +1,253 @@
+// <copyright file="DependencyAnalyzer.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// </copyright>
+
+using Newtonsoft.Json.Linq;
+
+namespace FabricUpgradePowerShellModule.Utilities
+{
+    /// <summary>
+    /// Analyzes dependencies between ADF resources to determine which resources are actually used.
+    /// </summary>
+    public static class DependencyAnalyzer
+    {
+        /// <summary>
+        /// Analyze ADF resources to find which datasets and linked services are actually used by pipelines.
+        /// </summary>
+        /// <param name="pipelines">Dictionary of pipeline definitions.</param>
+        /// <param name="datasets">Dictionary of dataset definitions.</param>
+        /// <param name="usedDatasets">Set to populate with dataset names that are used.</param>
+        /// <param name="usedLinkedServices">Set to populate with linked service names that are used.</param>
+        public static void AnalyzeResourceDependencies(
+            Dictionary<string, JObject> pipelines,
+            Dictionary<string, JObject> datasets,
+            HashSet<string> usedDatasets,
+            HashSet<string> usedLinkedServices)
+        {
+            // First, analyze pipeline dependencies to find used datasets and direct linked service references
+            AnalyzePipelineDependencies(pipelines, usedDatasets, usedLinkedServices);
+
+            // Then, analyze dataset dependencies to find linked services used by datasets
+            AnalyzeDatasetDependencies(datasets, usedDatasets, usedLinkedServices);
+        }
+
+        /// <summary>
+        /// Analyze pipeline activities to find which datasets and linked services are referenced.
+        /// </summary>
+        /// <param name="pipelines">Dictionary of pipeline definitions.</param>
+        /// <param name="usedDatasets">Set to populate with dataset names that are used.</param>
+        /// <param name="usedLinkedServices">Set to populate with linked service names that are used.</param>
+        private static void AnalyzePipelineDependencies(
+            Dictionary<string, JObject> pipelines,
+            HashSet<string> usedDatasets,
+            HashSet<string> usedLinkedServices)
+        {
+            foreach (var pipelineEntry in pipelines)
+            {
+                JToken pipelineToken = pipelineEntry.Value;
+                JArray activities = pipelineToken.SelectToken("properties.activities") as JArray;
+
+                if (activities != null)
+                {
+                    foreach (JObject activity in activities)
+                    {
+                        AnalyzeActivityDependencies(activity, usedDatasets, usedLinkedServices);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Analyze a single activity to find dataset and linked service dependencies.
+        /// </summary>
+        /// <param name="activity">The activity to analyze.</param>
+        /// <param name="usedDatasets">Set to populate with dataset names that are used.</param>
+        /// <param name="usedLinkedServices">Set to populate with linked service names that are used.</param>
+        private static void AnalyzeActivityDependencies(JObject activity, HashSet<string> usedDatasets, HashSet<string> usedLinkedServices)
+        {
+            // Check for dataset references in inputs and outputs
+            var inputs = activity.SelectToken("inputs") as JArray;
+            var outputs = activity.SelectToken("outputs") as JArray;
+
+            if (inputs != null)
+            {
+                foreach (JObject input in inputs)
+                {
+                    string datasetName = input.SelectToken("referenceName")?.ToString();
+                    if (!string.IsNullOrEmpty(datasetName))
+                    {
+                        usedDatasets.Add(datasetName);
+                    }
+                }
+            }
+
+            if (outputs != null)
+            {
+                foreach (JObject output in outputs)
+                {
+                    string datasetName = output.SelectToken("referenceName")?.ToString();
+                    if (!string.IsNullOrEmpty(datasetName))
+                    {
+                        usedDatasets.Add(datasetName);
+                    }
+                }
+            }
+
+            // Check for dataset references in activity type properties
+            string activityType = activity.SelectToken("type")?.ToString();
+            
+            // Many activities reference datasets through typeProperties
+            var typeProperties = activity.SelectToken("typeProperties");
+            if (typeProperties != null)
+            {
+                // Check for datasetId references (used in Lookup activities)
+                string datasetId = typeProperties.SelectToken("datasetId")?.ToString();
+                if (!string.IsNullOrEmpty(datasetId))
+                {
+                    usedDatasets.Add(datasetId);
+                }
+
+                // Check for dataset references in source/sink
+                var source = typeProperties.SelectToken("source");
+                var sink = typeProperties.SelectToken("sink");
+                
+                // These might contain dataset references indirectly
+                CheckForDatasetReferences(source, usedDatasets);
+                CheckForDatasetReferences(sink, usedDatasets);
+            }
+
+            // Check for direct linked service references (e.g., in Web activities)
+            if (activityType == "WebActivity" || activityType == "WebHook")
+            {
+                string linkedServiceName = activity.SelectToken("typeProperties.linkedServiceName.referenceName")?.ToString();
+                if (!string.IsNullOrEmpty(linkedServiceName))
+                {
+                    usedLinkedServices.Add(linkedServiceName);
+                }
+            }
+
+            // Check for Azure Function activities
+            if (activityType == "AzureFunctionActivity")
+            {
+                string linkedServiceName = activity.SelectToken("typeProperties.functionAppSettings.linkedServiceName.referenceName")?.ToString();
+                if (!string.IsNullOrEmpty(linkedServiceName))
+                {
+                    usedLinkedServices.Add(linkedServiceName);
+                }
+            }
+
+            // Add more activity-specific linked service checks as needed
+        }
+
+        /// <summary>
+        /// Check a JToken for any dataset references.
+        /// </summary>
+        /// <param name="token">The token to check.</param>
+        /// <param name="usedDatasets">Set to populate with dataset names.</param>
+        private static void CheckForDatasetReferences(JToken token, HashSet<string> usedDatasets)
+        {
+            if (token == null) return;
+
+            // Look for any properties that might contain dataset references
+            foreach (var property in token.Children<JProperty>())
+            {
+                if (property.Name.ToLower().Contains("dataset") && property.Value?.Type == JTokenType.String)
+                {
+                    string datasetName = property.Value.ToString();
+                    if (!string.IsNullOrEmpty(datasetName))
+                    {
+                        usedDatasets.Add(datasetName);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Analyze datasets to find their linked service dependencies.
+        /// </summary>
+        /// <param name="datasets">Dictionary of dataset definitions.</param>
+        /// <param name="usedDatasets">Set of dataset names that are used.</param>
+        /// <param name="usedLinkedServices">Set to populate with linked service names that are used.</param>
+        private static void AnalyzeDatasetDependencies(
+            Dictionary<string, JObject> datasets,
+            HashSet<string> usedDatasets,
+            HashSet<string> usedLinkedServices)
+        {
+            foreach (var datasetEntry in datasets)
+            {
+                if (usedDatasets.Contains(datasetEntry.Key))
+                {
+                    string linkedServiceName = datasetEntry.Value.SelectToken("properties.linkedServiceName.referenceName")?.ToString();
+                    if (!string.IsNullOrEmpty(linkedServiceName))
+                    {
+                        usedLinkedServices.Add(linkedServiceName);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Filter datasets and linked services to include only those used by pipelines.
+        /// </summary>
+        /// <param name="pipelines">Dictionary of pipeline definitions.</param>
+        /// <param name="allDatasets">Dictionary of all available dataset definitions.</param>
+        /// <param name="allLinkedServices">Dictionary of all available linked service definitions.</param>
+        /// <param name="alerts">Alert collector for logging messages.</param>
+        /// <returns>A tuple containing filtered datasets and linked services.</returns>
+        public static (Dictionary<string, JObject> FilteredDatasets, Dictionary<string, JObject> FilteredLinkedServices) 
+            FilterUnusedResources(
+                Dictionary<string, JObject> pipelines,
+                Dictionary<string, JObject> allDatasets,
+                Dictionary<string, JObject> allLinkedServices,
+                AlertCollector alerts)
+        {
+            var usedDatasets = new HashSet<string>();
+            var usedLinkedServices = new HashSet<string>();
+
+            // Analyze dependencies to find which resources are actually used
+            AnalyzeResourceDependencies(pipelines, allDatasets, usedDatasets, usedLinkedServices);
+
+            // Count original resources for logging
+            int originalDatasetCount = allDatasets.Count;
+            int originalLinkedServiceCount = allLinkedServices.Count;
+
+            // Filter datasets - keep only those that are used
+            var filteredDatasets = new Dictionary<string, JObject>();
+            foreach (var datasetEntry in allDatasets)
+            {
+                if (usedDatasets.Contains(datasetEntry.Key))
+                {
+                    filteredDatasets[datasetEntry.Key] = datasetEntry.Value;
+                }
+                else
+                {
+                    alerts.AddWarning($"Excluding unused dataset '{datasetEntry.Key}' from import");
+                }
+            }
+
+            // Filter linked services - keep only used ones
+            var filteredLinkedServices = new Dictionary<string, JObject>();
+            foreach (var linkedServiceEntry in allLinkedServices)
+            {
+                bool isUsed = usedLinkedServices.Contains(linkedServiceEntry.Key);
+
+                if (isUsed)
+                {
+                    // Only include used linked services
+                    filteredLinkedServices[linkedServiceEntry.Key] = linkedServiceEntry.Value;
+                }
+                else
+                {
+                    // Exclude unused linked services
+                    string linkedServiceType = linkedServiceEntry.Value.SelectToken("properties.type")?.ToString();
+                    alerts.AddWarning($"Excluding unused linked service '{linkedServiceEntry.Key}' of type '{linkedServiceType}' from import");
+                }
+            }
+
+            // Log summary
+            alerts.AddWarning($"Dependency analysis completed: Datasets {originalDatasetCount} ? {filteredDatasets.Count}, Linked Services {originalLinkedServiceCount} ? {filteredLinkedServices.Count}");
+
+            return (filteredDatasets, filteredLinkedServices);
+        }
+    }
+}

--- a/FabricUpgradePowerShellModule/FabricUpgradePowerShellModuleTests/EndToEndTests.cs
+++ b/FabricUpgradePowerShellModule/FabricUpgradePowerShellModuleTests/EndToEndTests.cs
@@ -126,7 +126,8 @@ namespace FabricUpgradePowerShellModuleTests
 
             runningProgress = new FabricUpgradeHandler().ImportAdfSupportFile(
                 runningProgress?.ToString(),
-                "./TestFiles/AdfSupportFiles/" + testConfig.AdfSupportFile);
+                "./TestFiles/AdfSupportFiles/" + testConfig.AdfSupportFile,
+                true);
 
             runningProgress = new FabricUpgradeHandler().ConvertToFabricResources(runningProgress?.ToString());
 
@@ -217,6 +218,93 @@ namespace FabricUpgradePowerShellModuleTests
 
                 Assert.AreEqual(expectedEvent, actualEndpointEvents[nEvent]);
             }
+        }
+
+        /// <summary>
+        /// Test dependency filtering functionality with the new cmdlet structure.
+        /// This test validates that the IncludeUnusedResources parameter works correctly.
+        /// </summary>
+        [TestMethod]
+        public void EndToEndUpgradePipeline_DependencyFiltering_Test()
+        {
+            FabricUpgradeProgress initialProgress = new FabricUpgradeProgress()
+            {
+                State = FabricUpgradeProgress.FabricUpgradeState.Succeeded,
+                Alerts = new List<FabricUpgradeAlert>(),
+                Resolutions = new List<FabricUpgradeResolution>()
+            };
+
+            // Test with IncludeUnusedResources = false (should filter unused resources)
+            FabricUpgradeProgress filteredProgress = new FabricUpgradeHandler().ImportAdfSupportFile(
+                initialProgress.ToString(),
+                "./TestFiles/AdfSupportFiles/PipelineWithCopy_JsonToJson_support_live.zip",
+                false, // Exclude unused resources
+                CancellationToken.None);
+
+            // Test with IncludeUnusedResources = true (should include all resources)
+            FabricUpgradeProgress unfilteredProgress = new FabricUpgradeHandler().ImportAdfSupportFile(
+                initialProgress.ToString(),
+                "./TestFiles/AdfSupportFiles/PipelineWithCopy_JsonToJson_support_live.zip",
+                true, // Include unused resources
+                CancellationToken.None);
+
+            // Both should succeed
+            Assert.AreEqual(FabricUpgradeProgress.FabricUpgradeState.Succeeded, filteredProgress.State, 
+                $"Filtered import failed: {string.Join(", ", filteredProgress.Alerts.Select(a => a.Details))}");
+            Assert.AreEqual(FabricUpgradeProgress.FabricUpgradeState.Succeeded, unfilteredProgress.State,
+                $"Unfiltered import failed: {string.Join(", ", unfilteredProgress.Alerts.Select(a => a.Details))}");
+
+            // The filtered version should have warnings about excluded resources (if any unused resources exist)
+            // The unfiltered version should include all resources
+            // Note: The exact comparison depends on the content of the test file
+            Console.WriteLine($"Filtered alerts: {filteredProgress.Alerts.Count}, Unfiltered alerts: {unfilteredProgress.Alerts.Count}");
+            
+            // If filtering worked, we should see different alert counts or different content
+            // (This is a basic validation - specific behavior depends on test file content)
+            Console.WriteLine("Dependency filtering test completed successfully");
+        }
+
+        /// <summary>
+        /// Test error handling for the new Import-AdfFactory cmdlet.
+        /// Since we don't have a full ADF API mock, this tests parameter validation.
+        /// </summary>
+        [TestMethod]
+        public async Task EndToEndUpgradePipeline_AdfFactory_ParameterValidation_TestAsync()
+        {
+            FabricUpgradeProgress initialProgress = new FabricUpgradeProgress()
+            {
+                State = FabricUpgradeProgress.FabricUpgradeState.Succeeded,
+                Alerts = new List<FabricUpgradeAlert>(),
+                Resolutions = new List<FabricUpgradeResolution>()
+            };
+
+            // Test missing required parameters
+            FabricUpgradeProgress result = await new FabricUpgradeHandler().ImportAdfFactoryAsync(
+                initialProgress.ToString(),
+                null, // Missing subscriptionId
+                "test-rg",
+                "test-factory",
+                "test-token",
+                null,
+                true,
+                CancellationToken.None).ConfigureAwait(false);
+
+            Assert.AreEqual(FabricUpgradeProgress.FabricUpgradeState.Failed, result.State);
+            Assert.IsTrue(result.Alerts.Any(a => a.Details.Contains("SubscriptionId, ResourceGroupName, FactoryName, and AdfToken are all required")));
+
+            // Test missing factory name
+            result = await new FabricUpgradeHandler().ImportAdfFactoryAsync(
+                initialProgress.ToString(),
+                "test-sub",
+                "test-rg",
+                null, // Missing factoryName
+                "test-token",
+                null,
+                true,
+                CancellationToken.None).ConfigureAwait(false);
+
+            Assert.AreEqual(FabricUpgradeProgress.FabricUpgradeState.Failed, result.State);
+            Assert.IsTrue(result.Alerts.Any(a => a.Details.Contains("SubscriptionId, ResourceGroupName, FactoryName, and AdfToken are all required")));
         }
 
         private class EndToEndTestConfig

--- a/FabricUpgradePowerShellModule/FabricUpgradePowerShellModuleTests/HandlerTests.cs
+++ b/FabricUpgradePowerShellModule/FabricUpgradePowerShellModuleTests/HandlerTests.cs
@@ -31,7 +31,8 @@ namespace FabricUpgradePowerShellModuleTests
 
             FabricUpgradeProgress actualResponse = new FabricUpgradeHandler().ImportAdfSupportFile(
                 testConfig.Progress?.ToString(),
-                "./TestFiles/AdfSupportFiles/" + testConfig.AdfSupportFile);
+                "./TestFiles/AdfSupportFiles/" + testConfig.AdfSupportFile,
+                true);
 
             JObject actualResponseObject = actualResponse.ToJObject();
 
@@ -79,7 +80,8 @@ namespace FabricUpgradePowerShellModuleTests
 
             FabricUpgradeProgress importResponse = new FabricUpgradeHandler().ImportAdfSupportFile(
                 testConfig.Progress?.ToString(),
-                "./TestFiles/AdfSupportFiles/" + testConfig.AdfSupportFile);
+                "./TestFiles/AdfSupportFiles/" + testConfig.AdfSupportFile,
+                true);
 
             FabricUpgradeProgress actualConvertResponse = new FabricUpgradeHandler().ConvertToFabricResources(importResponse.ToString());
 


### PR DESCRIPTION
1. Add support to fetch resources via APIs instead of support files
2. Add support for migrating at factory level instead of per pipeline.
3. Also allows excluding unused resources from upgrade.