### PR TITLE
Write result to output when workspace is present

### DIFF
--- a/FabricUpgradePowerShellModule/FabricUpgradePowerShellModule/ExposedCommands.cs
+++ b/FabricUpgradePowerShellModule/FabricUpgradePowerShellModule/ExposedCommands.cs
@@ -394,10 +394,7 @@ namespace FabricUpgradePowerShellModule
                         cancellationToken);
 
                     string result = task.GetAwaiter().GetResult().ToString();
-                    if (this.EnableVerboseLogging)
-                    {
-                        WriteObject(result);
-                    }
+                    WriteObject(result);
                 }
                 else
                 {


### PR DESCRIPTION
Result does not get printed to powershell terminal in case when the workspace is present. So, the error was not getting printed.

<img width="1698" height="286" alt="image" src="https://github.com/user-attachments/assets/61121c09-54a9-4aeb-9218-201563c73856" />

Removed the condition of VerboseLogging from the WriteObject statement and now it prints the result.

<img width="1698" height="550" alt="image" src="https://github.com/user-attachments/assets/69512c55-4b2e-4dd6-933c-ecb9f2654195" />
